### PR TITLE
s/desc/onfalse

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ To create your own diagnostics:
 (def unrealistic-expectations
   {:table-cache-hit
    {:pred #(> (:ratio %) 0.999)
-    :desc "The cache hit ratio is not as insanely high as I'd like."
+    :onfalse "The cache hit ratio is not as insanely high as I'd like."
     :idfn :name}})
 
 (doseq [w (pgex/diagnose-warnings

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Clojure toolbox for inspecting and diagnosing PostgreSQL databases.
 perrygeo/postgres-extras-clj {:mvn/version "0.1.5"}
 ```
 
-* [Clojar Releases](https://clojars.org/com.github.perrygeo/postgres-extras-clj)
+* [Clojars](https://clojars.org/com.github.perrygeo/postgres-extras-clj)
 * [Github](https://github.com/perrygeo/postgres-extras-clj)
 * [Documentation](https://cljdoc.org/d/com.github.perrygeo/postgres-extras-clj/)
 * [CI tests](https://github.com/perrygeo/postgres-extras-clj/actions/workflows/test.yml)

--- a/examples/with_next_jdbc.clj
+++ b/examples/with_next_jdbc.clj
@@ -134,7 +134,7 @@
   (def unrealistic-expectations
     {:table-cache-hit
      {:pred #(> (:ratio %) 0.999)
-      :desc "The cache hit ratio is not as insanely high as I'd like."
+      :onfalse "The cache hit ratio is not as insanely high as I'd like."
       :idfn :name}})
 
   (doseq [w (pgex/diagnose-warnings

--- a/src/postgres_extras_clj/core.clj
+++ b/src/postgres_extras_clj/core.clj
@@ -86,7 +86,9 @@
                :unused-indexes (unused-indexes db {:min_scans 50})
                :vacuum-stats (vacuum-stats db)}]
     (into {} (map (fn [[k v]]
-                    [k (take limit v)])
+                    [k (if (nil? v)
+                         nil
+                         (take limit v))])
                   stats))))
 
 ;;;

--- a/test/postgres_extras_clj/core_test.clj
+++ b/test/postgres_extras_clj/core_test.clj
@@ -42,7 +42,7 @@
 (def test-fns
   {:table-cache-hit
    {:pred #(> (:ratio %) 0.985)
-    :desc "Table sees high block IO relative to buffer cache hit"
+    :onfalse "Table sees high block IO relative to buffer cache hit"
     :idfn :name}})
 
 (defn mock-stats-buffered []


### PR DESCRIPTION
Changed :desc to :onfalse to more clearly indicate the intent. Some
general edits to the diagnostic fns to make the predicates clear.
