### PR TITLE
improve outliers and calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This project uses MAJOR.MINOR.COMMIT-COUNT versioning
 
 ## Unreleased
 
+### Changes
+
+- Remove the outlier-legacy and calls-legacy functions, which served no purpose that I could tell.
+- Changed the outliers and calls return maps to use :exec_time_ms (bigdecimal, explicit units) instead of :exec_time.
+- Similarly, changed the outliers and calls return maps with :sync_io_time_ms
+
 ## [0.1.12] - 2024-07-08
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ These are valuable for looking at your database through an operations or DBA len
 | `long-running-queries` | All queries longer than the threshold by descending duration |
 | `null-indexes` | Find indexes with a high ratio of NULL values |
 | `outliers` | Queries that have longest execution time in aggregate. |
-| `outliers-legacy` | Queries that have longest execution time in aggregate |
 | `records-rank` | All tables and the number of rows in each ordered by number of rows descending |
 | `seq-scans` | Count of sequential scans by table descending by order |
 | `table-cache-hit` | Calculates your cache hit rate for reading tables |

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,0 +1,3 @@
+{:cljdoc.doc/tree
+ [["Readme" {:file "README.md"}]
+  ["Changes" {:file "CHANGELOG.md"}]]}

--- a/resources/sql/postgres_extras.sql
+++ b/resources/sql/postgres_extras.sql
@@ -254,10 +254,10 @@ FROM
 /* HUG_PSQL_EXTRAS: Queries that have the highest frequency of execution */
 SELECT
     query AS query,
-    interval '1 millisecond' * total_exec_time AS exec_time,
+    EXTRACT(milliseconds FROM (interval '1 millisecond' * total_exec_time)) AS exec_time_ms,
     (total_exec_time / sum(total_exec_time) OVER ()) AS exec_time_ratio,
     calls,
-    interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
+    EXTRACT(milliseconds FROM (interval '1 millisecond' * (blk_read_time + blk_write_time))) AS sync_io_time_ms
 FROM
     pg_stat_statements
 WHERE
@@ -273,33 +273,6 @@ WHERE
 ORDER BY
     calls DESC
 LIMIT :v:limit;
-
--- :name calls-legacy
--- :command :query
--- :result :many
--- :doc Queries that have the highest frequency of execution (legacy)
-/* HUG_PSQL_EXTRAS: Queries that have the highest frequency of execution */
-SELECT
-    query AS query,
-    interval '1 millisecond' * total_time AS exec_time,
-    (total_time / sum(total_time) OVER ()) AS exec_time_ratio,
-    calls,
-    interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
-FROM
-    pg_stat_statements
-WHERE
-    userid = (
-        SELECT
-            usesysid
-        FROM
-            pg_user
-        WHERE
-            usename = CURRENT_USER
-        LIMIT 1)
-    AND query NOT LIKE '/* HUG_PSQL_EXTRAS:%'
-ORDER BY
-    calls DESC
-LIMIT 10;
 
 -- :name connections
 -- :command :query
@@ -608,10 +581,10 @@ SELECT
 /* HUG_PSQL_EXTRAS: Queries that have longest execution time in aggregate */
 SELECT
     query AS query,
-    interval '1 millisecond' * total_exec_time AS exec_time,
+    EXTRACT(milliseconds FROM (interval '1 millisecond' * total_exec_time)) AS exec_time_ms,
     (total_exec_time / sum(total_exec_time) OVER ()) AS prop_exec_time,
     calls,
-    interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
+    EXTRACT(milliseconds FROM (interval '1 millisecond' * (blk_read_time + blk_write_time))) AS sync_io_time_ms
 FROM
     pg_stat_statements
 WHERE
@@ -627,33 +600,6 @@ WHERE
 ORDER BY
     total_exec_time DESC
 LIMIT :v:limit;
-
--- :name outliers-legacy
--- :command :query
--- :result :many
--- :doc Queries that have longest execution time in aggregate
-/* HUG_PSQL_EXTRAS: Queries that have longest execution time in aggregate */
-SELECT
-    query AS query,
-    interval '1 millisecond' * total_time AS exec_time,
-    (total_time / sum(total_time) OVER ()) AS prop_exec_time,
-    calls,
-    interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
-FROM
-    pg_stat_statements
-WHERE
-    userid = (
-        SELECT
-            usesysid
-        FROM
-            pg_user
-        WHERE
-            usename = CURRENT_USER
-        LIMIT 1)
-    AND query NOT LIKE '/* HUG_PSQL_EXTRAS:%'
-ORDER BY
-    total_time DESC
-LIMIT 10;
 
 -- :name records-rank
 -- :command :query


### PR DESCRIPTION
* Remove the "-legacy" calls, which served no purpose that I could tell.
* Changed the `outliers` and `calls` return maps to use :exec_time_ms (bigdecimal, explicit units) instead of :exec_time.
* Similarly, changed the `outliers` and `calls` return maps to return :sync_io_time_ms

